### PR TITLE
removing non-ascii characters

### DIFF
--- a/pkg/systray/util.go
+++ b/pkg/systray/util.go
@@ -2,6 +2,7 @@ package systray
 
 import (
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -23,8 +24,10 @@ func acceptVal(clipboardInstance *clipboard, menuItem menuItem, val string) {
 	//truncate to fit on screen
 	valTrunc := truncateVal(clipboardInstance, val)
 
-	menuItem.instance.SetTitle(valTrunc)
-	menuItem.instance.SetTooltip(val)
+	// menuItem.instance.SetTitle(valTrunc)
+	// menuItem.instance.SetTooltip(val)
+	menuItem.instance.SetTitle(removeNonASCII(valTrunc))
+	menuItem.instance.SetTooltip(removeNonASCII(val))
 
 	clipboardInstance.valExistsMap[val] = true
 	clipboardInstance.menuItemToVal[menuItem.instance] = val
@@ -100,6 +103,12 @@ func truncateVal(clipboardInstance *clipboard, val string) string {
 		valTrunc = val[:clipboardInstance.truncateLength] + "... (" + strconv.Itoa(len(val)) + " chars)"
 	}
 	return valTrunc
+}
+
+func removeNonASCII(val string) string {
+	removeNonASCII := regexp.MustCompile("[[:^ascii:]]")
+	nonASCIIStr := removeNonASCII.ReplaceAllLiteralString(val, "")
+	return strings.TrimSpace(nonASCIIStr)
 }
 
 func getTitle(menuItem menuItem) string {


### PR DESCRIPTION
one possible fix for https://github.com/prashantgupta24/go-clip/issues/7

Removes non-ascii characters only from display. They can still be copied over from the actual menu.

However, I am still not able to copy over unicode such as `भारत`. It always appears as `????`.